### PR TITLE
`initial`

### DIFF
--- a/Sources/Bind/Output.swift
+++ b/Sources/Bind/Output.swift
@@ -68,6 +68,21 @@ public class Output<Value>: Unbindable {
         return subscription
     }
 
+    /**
+     `initial` allows the caller to specify an initial value to be populated into the Output through another mechanism
+     other than the initialiser. If a value is already populated, this function just returns the receiver without doing
+     anything
+     - Parameter value: The initial value
+     - Returns: The same Output but with the initial value populated
+     */
+    public func initial(_ value: Value) -> Output<Value> {
+        if self.value == nil {
+            update(withValue: value)
+        }
+
+        return self
+    }
+
     public func debug(identifier: String) -> Output<Value> {
         debugIdentifier = identifier
         return self

--- a/Tests/BindTests/OutputTests.swift
+++ b/Tests/BindTests/OutputTests.swift
@@ -309,6 +309,30 @@ final class OutputTests: XCTestCase {
         XCTAssertEqual(reduced.latest, 15)
     }
 
+    func testInitialValueFunctionChain() {
+        let initial = Output<Int>().initial(10)
+        XCTAssertEqual(initial.latest, 10)
+
+        let alreadyPopulated = Output<Int>(value: 5).initial(10)
+        XCTAssertEqual(alreadyPopulated.latest, 5)
+
+        let left = Output(value: 3)
+        let right = Output<Int>()
+
+        let combined = Output
+            .combine(left, right)
+            .map(+)
+            .initial(20)
+
+        XCTAssertEqual(combined.latest, 20)
+
+        left.update(withValue: 4)
+        XCTAssertEqual(combined.latest, 20)
+
+        right.update(withValue: 6)
+        XCTAssertEqual(combined.latest, 10)
+    }
+
     func testDebug() {
         let printer = PrinterMock()
         let output1 = Output<Bool>(printer: printer)


### PR DESCRIPTION
Adding feature that allows you  to specify an initial value for an output via a function call, instead of just via the initialiser